### PR TITLE
Implement API utilities with validation and retry

### DIFF
--- a/blockchain-news-app/package-lock.json
+++ b/blockchain-news-app/package-lock.json
@@ -13,7 +13,8 @@
         "next": "15.3.4",
         "next-auth": "^4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -8309,6 +8310,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/blockchain-news-app/package.json
+++ b/blockchain-news-app/package.json
@@ -18,7 +18,8 @@
     "next": "15.3.4",
     "next-auth": "^4",
     "contentful": "^10",
-    "coingecko-api": "^1"
+    "coingecko-api": "^1",
+    "zod": "^3"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/blockchain-news-app/src/__tests__/api.test.ts
+++ b/blockchain-news-app/src/__tests__/api.test.ts
@@ -1,0 +1,46 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { getCryptoPrice, fetchWithRetry } from '../lib';
+import { APIError, ValidationError } from '../lib';
+
+const SUCCESS_RESPONSE = { bitcoin: { usd: 50000 } };
+
+describe('getCryptoPrice', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns price for valid params', async () => {
+    (fetch as unknown as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => SUCCESS_RESPONSE,
+    });
+    const price = await getCryptoPrice({ id: 'bitcoin', vs_currency: 'usd' });
+    expect(price).toBe(50000);
+  });
+
+  it('throws validation error for invalid params', async () => {
+    await expect(
+      getCryptoPrice({ id: '', vs_currency: '' }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('retries on failure and throws after max retries', async () => {
+    (fetch as unknown as Mock).mockRejectedValue(new Error('fail'));
+    await expect(fetchWithRetry('http://test')).rejects.toBeInstanceOf(
+      APIError,
+    );
+    expect(fetch as unknown as Mock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});

--- a/blockchain-news-app/src/lib/api.ts
+++ b/blockchain-news-app/src/lib/api.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { APIError, ValidationError } from './errors';
+
+const coinSchema = z.object({
+  id: z.string().min(1),
+  vs_currency: z.string().min(1),
+});
+
+interface FetchOptions extends RequestInit {
+  timeoutMs?: number;
+  retries?: number;
+}
+
+export async function fetchWithRetry<T = unknown>(
+  url: string,
+  options: FetchOptions = {},
+): Promise<T> {
+  const { timeoutMs = 5000, retries = 2, ...init } = options;
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    clearTimeout(id);
+    if (!response.ok) {
+      throw new APIError(`Request failed with status ${response.status}`);
+    }
+    return (await response.json()) as T;
+  } catch (err) {
+    clearTimeout(id);
+    if (retries > 0) {
+      return fetchWithRetry(url, { ...options, retries: retries - 1 });
+    }
+    if (err instanceof APIError) throw err;
+    throw new APIError('Network request failed', { cause: err });
+  }
+}
+
+export async function getCryptoPrice(params: {
+  id: string;
+  vs_currency: string;
+}): Promise<number> {
+  const parsed = coinSchema.safeParse(params);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid parameters');
+  }
+  const apiKey = process.env.COINGECKO_API_KEY;
+  const query = new URLSearchParams({
+    ids: parsed.data.id,
+    vs_currencies: parsed.data.vs_currency,
+    x_cg_pro_api_key: apiKey || '',
+  }).toString();
+  const url = `https://api.coingecko.com/api/v3/simple/price?${query}`;
+  const data = await fetchWithRetry<Record<string, Record<string, number>>>(
+    url,
+    { timeoutMs: 7000, retries: 3 },
+  );
+  const price = data[parsed.data.id]?.[parsed.data.vs_currency];
+  if (typeof price !== 'number') {
+    throw new APIError('Price data not found');
+  }
+  return price;
+}

--- a/blockchain-news-app/src/lib/errors.ts
+++ b/blockchain-news-app/src/lib/errors.ts
@@ -1,0 +1,14 @@
+export class BaseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    if (options?.cause) {
+      // Add cause property for Node >= 16
+      (this as unknown as { cause?: unknown }).cause = options.cause;
+    }
+    this.name = this.constructor.name;
+  }
+}
+
+export class ValidationError extends BaseError {}
+
+export class APIError extends BaseError {}

--- a/blockchain-news-app/src/lib/index.ts
+++ b/blockchain-news-app/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './errors';

--- a/blockchain-news-app/vitest.config.ts
+++ b/blockchain-news-app/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
   },
-})
+});


### PR DESCRIPTION
## Summary
- add API util functions for external crypto requests
- provide custom error classes
- export new utilities
- test validation and retry logic
- format vitest config and upgrade dependencies

## Testing
- `npm test`
- `npm run e2e`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856f80a22f88322a4f011d5f7b8a19a