### PR TITLE
Add security headers and API rewrites

### DIFF
--- a/blockchain-news-app/next.config.ts
+++ b/blockchain-news-app/next.config.ts
@@ -1,7 +1,82 @@
 import type { NextConfig } from 'next';
+import type { Header, Rewrite } from 'next/dist/lib/load-custom-routes';
 
+/**
+ * Next.js configuration for the Blockchain News website.
+ * - Allows images from common crypto logo sources.
+ * - Adds security headers for all routes.
+ * - Provides API rewrites for external crypto data providers.
+ */
 const nextConfig: NextConfig = {
-  /* config options here */
+  /**
+   * Remote patterns define external hosts that can serve images.
+   * This is required for displaying cryptocurrency logos.
+   */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'assets.coingecko.com',
+        pathname: '/coins/images/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 's2.coinmarketcap.com',
+        pathname: '/static/img/coins/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'cryptologos.cc',
+        pathname: '/logos/**',
+      },
+    ],
+  },
+
+  /**
+   * Security headers applied to every route.
+   * Adjust policies as needed for the deployment environment.
+   */
+  async headers(): Promise<Header[]> {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; img-src 'self' https:; script-src 'self'; style-src 'self' 'unsafe-inline'",
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
+      },
+    ];
+  },
+
+  /**
+   * Rewrites proxy API requests to external services so API keys remain secret.
+   */
+  async rewrites(): Promise<Rewrite[]> {
+    return [
+      {
+        source: '/api/coingecko/:path*',
+        destination: 'https://api.coingecko.com/:path*',
+      },
+      {
+        source: '/api/coinmarketcap/:path*',
+        destination: 'https://pro-api.coinmarketcap.com/:path*',
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/blockchain-news-app/src/__tests__/next-config.test.ts
+++ b/blockchain-news-app/src/__tests__/next-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import config from '../../next.config';
+
+// Helper to unwrap async results
+async function getConfigValue<T>(val: T | Promise<T>): Promise<T> {
+  return await (val as Promise<T>);
+}
+
+describe('next.config.ts', () => {
+  it('includes crypto logo remote patterns', () => {
+    const patterns = config.images?.remotePatterns || [];
+    expect(patterns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hostname: 'assets.coingecko.com' }),
+        expect.objectContaining({ hostname: 's2.coinmarketcap.com' }),
+        expect.objectContaining({ hostname: 'cryptologos.cc' }),
+      ]),
+    );
+  });
+
+  it('provides security headers', async () => {
+    const headers = await getConfigValue(
+      config.headers?.() ?? Promise.resolve([]),
+    );
+    expect(headers[0].headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'Content-Security-Policy' }),
+        expect.objectContaining({ key: 'X-Content-Type-Options' }),
+      ]),
+    );
+  });
+
+  it('rewrites crypto API routes', async () => {
+    const rewrites = await getConfigValue(config.rewrites?.());
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          destination: 'https://api.coingecko.com/:path*',
+        }),
+        expect.objectContaining({
+          destination: 'https://pro-api.coinmarketcap.com/:path*',
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow remote images for crypto logos
- set security headers via `headers()`
- add rewrites for CoinGecko and CoinMarketCap APIs
- test that Next.js config exposes these options

## Testing
- `npm test`
- `npm run e2e`
- `npm run build`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_685707577b3c83228dfffc9a9975f83d