### PR TITLE
Add type interfaces for crypto price

### DIFF
--- a/blockchain-news-app/src/__tests__/api.test.ts
+++ b/blockchain-news-app/src/__tests__/api.test.ts
@@ -26,8 +26,12 @@ describe('getCryptoPrice', () => {
       ok: true,
       json: async () => SUCCESS_RESPONSE,
     });
-    const price = await getCryptoPrice({ id: 'bitcoin', vs_currency: 'usd' });
-    expect(price).toBe(50000);
+    const result = await getCryptoPrice({ id: 'bitcoin', vs_currency: 'usd' });
+    expect(result).toEqual({
+      id: 'bitcoin',
+      vs_currency: 'usd',
+      price: 50000,
+    });
   });
 
   it('throws validation error for invalid params', async () => {

--- a/blockchain-news-app/src/lib/api.ts
+++ b/blockchain-news-app/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { APIError, ValidationError } from './errors';
+import type { CryptoPrice } from '../types';
 
 const coinSchema = z.object({
   id: z.string().min(1),
@@ -38,7 +39,7 @@ export async function fetchWithRetry<T = unknown>(
 export async function getCryptoPrice(params: {
   id: string;
   vs_currency: string;
-}): Promise<number> {
+}): Promise<CryptoPrice> {
   const parsed = coinSchema.safeParse(params);
   if (!parsed.success) {
     throw new ValidationError('Invalid parameters');
@@ -58,5 +59,9 @@ export async function getCryptoPrice(params: {
   if (typeof price !== 'number') {
     throw new APIError('Price data not found');
   }
-  return price;
+  return {
+    id: parsed.data.id,
+    vs_currency: parsed.data.vs_currency,
+    price,
+  };
 }

--- a/blockchain-news-app/src/types/index.ts
+++ b/blockchain-news-app/src/types/index.ts
@@ -1,0 +1,12 @@
+export interface CryptoPrice {
+  id: string;
+  vs_currency: string;
+  price: number;
+}
+
+export interface Article {
+  id: string;
+  title: string;
+  content: string;
+  publishedAt: string;
+}


### PR DESCRIPTION
## Summary
- define `CryptoPrice` and `Article` interfaces
- return a `CryptoPrice` from `getCryptoPrice`
- update tests for new interface usage

## Testing
- `npm test`
- `npm run e2e`
- `npm run lint`
- `npm run build`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_685709ac498083228aeec387da94487e